### PR TITLE
Close all buffers to generate a VimLeave event

### DIFF
--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -210,7 +210,7 @@ M.win_enter_event = function()
       if position ~= "current" then
         -- close_if_last_window just doesn't make sense for a split style
         log.trace("last window, closing")
-        vim.cmd("q!")
+        vim.cmd("qa!")
         return
       end
     end


### PR DESCRIPTION
Running the 'qa!' command makes sure that all buffers are closed and that a VimLeave event is generated. This is (amongst other things) important for session saving plugins. I was running into a problem where my sessions were not saved if the neo-tree was the last window to automatically close. It appears that just running 'q!' does not generate a VimLeave event.